### PR TITLE
Scalapb upgrade

### DIFF
--- a/project/Web.scala
+++ b/project/Web.scala
@@ -1,7 +1,7 @@
 import play.sbt.PlayImport.PlayKeys
 import PlayKeys.playMonitoredFiles
 import play.twirl.sbt.Import.TwirlKeys
-import sbt.Keys.{sourceDirectories, sourceDirectory, unmanagedSourceDirectories}
+import sbt.Keys.{sourceDirectories, sourceDirectory, unmanagedSourceDirectories, sourceGenerators}
 import sbt._
 import sbtprotoc.ProtocPlugin.autoImport.PB
 
@@ -21,6 +21,7 @@ object Web {
     PB.targets in Compile := Seq(
       PB.gens.java -> ((sourceDirectory in Compile).value / "protobuf_generated")
     ),
+    sourceGenerators in Compile -= (PB.generate in Compile).taskValue,
     unmanagedSourceDirectories in Compile += ((sourceDirectory in Compile).value / "protobuf_generated")
   )
 


### PR DESCRIPTION
Extract protobuf compilation out of main Compile scope so that protobuf generation has to be run by “sbt protocGenerate“ instead of “set compile” (which compiles the entire project).

Note: haven't found a solution to disallow generated protobuf files to be cleaned by "sbt clean" task (It is probably because protobuf clean task is binded with the original sbt clean, but I haven't found a solution to extract out )

Note: I still decided to keep generated files to be in Java, because it has better supports from Google.